### PR TITLE
WIP:  Adds form types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "moneyphp/money": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^8.5",
+        "symfony/form": "^4.2 || ^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Form/Type/CurrencyMoneyPHPType.php
+++ b/src/Form/Type/CurrencyMoneyPHPType.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Money\MoneyBundle\Form\Type;
+
+use Money\Currencies;
+use Money\Currency;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CurrencyMoneyPHPType extends AbstractType
+{
+    /**
+     * @var Currencies
+     */
+    private $currencies;
+
+    /**
+     * @param Currencies $currencies
+     */
+    public function __construct(Currencies $currencies)
+    {
+        $this->currencies = $currencies;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getParent()
+    {
+        return ChoiceType::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefaults([
+                'choice_loader' => new CallbackChoiceLoader(function () {
+                    $currencies = array_map(
+                        static function (Currency $currency) {
+                            return $currency->getCode();
+                        }, iterator_to_array($this->currencies)
+                    );
+
+                    ksort($currencies);
+
+                    return array_combine($currencies, $currencies);
+                }),
+            ])
+        ;
+    }
+}

--- a/src/Form/Type/CurrencyMoneyPHPType.php
+++ b/src/Form/Type/CurrencyMoneyPHPType.php
@@ -48,7 +48,7 @@ class CurrencyMoneyPHPType extends AbstractType
                         }, iterator_to_array($this->currencies)
                     );
 
-                    ksort($currencies);
+                    sort($currencies);
 
                     return array_combine($currencies, $currencies);
                 }),

--- a/src/Form/Type/CurrencyMoneyPHPType.php
+++ b/src/Form/Type/CurrencyMoneyPHPType.php
@@ -52,6 +52,7 @@ class CurrencyMoneyPHPType extends AbstractType
 
                     return array_combine($currencies, $currencies);
                 }),
+                'choice_translation_domain' => false,
             ])
         ;
     }

--- a/src/Form/Type/MoneyPHPType.php
+++ b/src/Form/Type/MoneyPHPType.php
@@ -20,6 +20,7 @@ class MoneyPHPType extends AbstractType
         $resolver
             ->setDefaults([
                 'data_class' => Money::class,
+                'currencies_preferred_choices' => [],
             ]);
     }
 
@@ -30,7 +31,9 @@ class MoneyPHPType extends AbstractType
     {
         $builder
             ->add('amount', NumberType::class)
-            ->add('currency', CurrencyMoneyPHPType::class)
+            ->add('currency', CurrencyMoneyPHPType::class, [
+                'preferred_choices' => $options['currencies_preferred_choices'],
+            ])
         ;
     }
 }

--- a/src/Form/Type/MoneyPHPType.php
+++ b/src/Form/Type/MoneyPHPType.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Money\MoneyBundle\Form\Type;
+
+use Money\Money;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class MoneyPHPType extends AbstractType
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefaults([
+                'data_class' => Money::class,
+            ]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('amount', NumberType::class)
+            ->add('currency', CurrencyMoneyPHPType::class)
+        ;
+    }
+}


### PR DESCRIPTION
This PR 
1. intends to automatically create form types — one for `Money\Money` and an other one for a list of `Money\Currency`.
2. should not affect any user not using the form component.
3. should work out of the box if autowiring has been enabled

TODO:
- [x] add symfony receipe for flex (done: https://github.com/symfony/recipes-contrib/pull/831)
- [ ] add data transformer